### PR TITLE
Use alpine image, allow optional password and port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM postgres:alpine
+FROM alpine
 
-RUN apk update && apk add py-pip
+RUN apk update && apk add py-pip postgresql-client
 RUN pip install awscli --upgrade
 
 ENV PGDUMP_OPTIONS -Fc --no-acl --no-owner
@@ -16,7 +16,7 @@ RUN apk add tzdata
 RUN cp /usr/share/zoneinfo/Asia/Singapore /etc/localtime
 RUN echo "Asia/Singapore" > /etc/timezone
 
-ADD run.sh /run.sh
-RUN chmod +x /run.sh
+ADD run.sh run.sh
+RUN sed -i 's/\r$//' run.sh && chmod +x run.sh
 
-CMD ["/run.sh"]
+CMD ["/bin/sh", "run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -32,26 +32,26 @@ if [ -z "${POSTGRES_ENV_POSTGRES_USER}" ]; then
   exit 1
 fi
 
-if [ -z "${POSTGRES_ENV_POSTGRES_PASSWORD}" ]; then
-  echo "You need to set the POSTGRES_ENV_POSTGRES_PASS environment variable."
-  exit 1
-fi
-
 if [ -z "${POSTGRES_PORT_5432_TCP_ADDR}" ]; then
   echo "You need to set the POSTGRES_PORT_5432_TCP_ADDR environment variable or link to a container named POSTGRES."
   exit 1
 fi
 
 if [ -z "${POSTGRES_PORT_5432_TCP_PORT}" ]; then
-  echo "You need to set the POSTGRES_PORT_5432_TCP_PORT environment variable or link to a container named POSTGRES."
-  exit 1
+  echo "POSTGRES_PORT_5432_TCP_PORT not set, defaulting to 5432"
+  POSTGRES_PORT_5432_TCP_PORT=5432
+fi
+
+
+if [ -z "${POSTGRES_ENV_POSTGRES_PASSWORD}" ]; then
+  echo "POSTGRES_ENV_POSTGRES_PASSWORD not set, proceeding without a password"
+else
+  export PGPASSWORD=${POSTGRES_ENV_POSTGRES_PASSWORD}
 fi
 
 POSTGRES_HOST_OPTS="-h $POSTGRES_PORT_5432_TCP_ADDR -p $POSTGRES_PORT_5432_TCP_PORT -U $POSTGRES_ENV_POSTGRES_USER"
 
-echo "Starting dump of ${PGDUMP_DATABASE} database(s) from ${POSTGRES_PORT_5432_TCP_ADDR}..."
-
-export PGPASSWORD=${POSTGRES_ENV_POSTGRES_PASSWORD}
+echo "Starting dump of ${PGDUMP_DATABASE} database from ${POSTGRES_PORT_5432_TCP_ADDR}..."
 
 DUMPFILE="${PGDUMP_DATABASE}_$(date +%d-%b-%Y-%H-%M-%S).sql"
 pg_dump $PGDUMP_OPTIONS $POSTGRES_HOST_OPTS $PGDUMP_DATABASE > $DUMPFILE


### PR DESCRIPTION
- Use alpine instead of postgres-alpine because we only need pg_dump
- Allow optional password for insecure databases (like my local)
- Allow port to be set to the default of 5432 if the env is not found